### PR TITLE
リファクタ（アプリケーション層とインフラ層の依存関係を逆転 + 一部クラスを別パッケージに移動）

### DIFF
--- a/src/main/kotlin/org/azukazu/gtm/application/LineNotificator.kt
+++ b/src/main/kotlin/org/azukazu/gtm/application/LineNotificator.kt
@@ -1,0 +1,42 @@
+package org.azukazu.gtm.application
+
+import com.linecorp.bot.spring.boot.annotation.LineMessageHandler
+import org.azukazu.gtm.domain.model.ErrorMessageInterface
+import org.azukazu.gtm.domain.model.image_info.ImageInfo
+import org.azukazu.gtm.domain.model.search_word.SearchWord
+import org.springframework.stereotype.Component
+
+/**
+ * LINEへの通知を行うNotificator
+ */
+@Component
+@LineMessageHandler
+interface LineNotificator {
+
+    /**
+     * 画像付きメッセージを通知する
+     */
+    fun notifyOfMessageWithImage(
+        replyToken: ReplyToken,
+        searchWord: SearchWord,
+        imageInfo: ImageInfo
+    )
+
+    /**
+     * メッセージを通知する
+     */
+    fun notifyOfMessage(
+        replyToken: ReplyToken,
+        text: String
+    )
+
+    /**
+     * エラーメッセージを通知する
+     */
+    fun notifyErrorMessage(
+        replyToken: ReplyToken,
+        errorMessage: ErrorMessageInterface
+    )
+}
+
+

--- a/src/main/kotlin/org/azukazu/gtm/application/NotifyLineOfErrorMessageApplicationService.kt
+++ b/src/main/kotlin/org/azukazu/gtm/application/NotifyLineOfErrorMessageApplicationService.kt
@@ -3,8 +3,7 @@ package org.azukazu.gtm.application
 import org.azukazu.gtm.domain.model.ErrorMessageInterface
 import org.azukazu.gtm.domain.model.GeneralErrorMessage
 import org.azukazu.gtm.domain.model.search_word.InvalidSearchWordException
-import org.azukazu.gtm.domain.model.line.ReplyToken
-import org.azukazu.gtm.infrastructure.transmission.line.LineNotificator
+import org.azukazu.gtm.infrastructure.transmission.line.messaging_api.LineMessagingApiClient
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -22,7 +21,7 @@ class NotifyLineOfErrorMessageApplicationService(
 
         logger.info("エラーメッセージの送信. リプライトークン = {}, エラーメッセージ = {}", replyToken.value, errorMessage)
 
-        lineNotificator.notifyLineOfErrorMessage(replyToken, errorMessage)
+        lineNotificator.notifyErrorMessage(replyToken, errorMessage)
 
         logger.info("エラーメッセージの送信が完了. リプライトークン = {},", replyToken.value)
     }

--- a/src/main/kotlin/org/azukazu/gtm/application/NotifyLineOfImageSearchResultApplicationService.kt
+++ b/src/main/kotlin/org/azukazu/gtm/application/NotifyLineOfImageSearchResultApplicationService.kt
@@ -1,9 +1,6 @@
 package org.azukazu.gtm.application
 
-import org.azukazu.gtm.infrastructure.transmission.line.LineNotificator
-import org.azukazu.gtm.infrastructure.transmission.photozou.PhotozouClient
 import org.azukazu.gtm.domain.model.search_word.SearchWord
-import org.azukazu.gtm.domain.model.line.ReplyToken
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -25,8 +22,8 @@ class NotifyLineOfImageSearchResultApplicationService(
         logger.info("検索画像の通知処理を開始. リプライトークン = {}, 検索ワード = {}", replyToken.value, searchWord.value)
 
         photozouClient.searchImages(searchWord)
-            ?.let { lineNotificator.notifyLineOfImage(replyToken, searchWord, it.shuffled()[0]) }
-            ?: lineNotificator.notifyLineOfMessage(replyToken, "検索結果が0件です。")
+            ?.let { lineNotificator.notifyOfMessageWithImage(replyToken, searchWord, it.shuffled()[0]) }
+            ?: lineNotificator.notifyOfMessage(replyToken, "検索結果が0件です。")
 
         logger.info("検索結果の通知が完了. リプライトークン = {}", replyToken.value)
     }

--- a/src/main/kotlin/org/azukazu/gtm/application/PhotozouClient.kt
+++ b/src/main/kotlin/org/azukazu/gtm/application/PhotozouClient.kt
@@ -1,0 +1,17 @@
+package org.azukazu.gtm.application
+
+import org.azukazu.gtm.domain.model.image_info.ImageInfo
+import org.azukazu.gtm.domain.model.search_word.SearchWord
+import org.springframework.stereotype.Component
+
+/**
+ * フォト蔵から画像を取得するクライアント
+ */
+@Component
+interface PhotozouClient {
+
+    /**
+     * 画像の検索
+     */
+    fun searchImages(searchWord: SearchWord): List<ImageInfo>?
+}

--- a/src/main/kotlin/org/azukazu/gtm/application/ReplyToken.kt
+++ b/src/main/kotlin/org/azukazu/gtm/application/ReplyToken.kt
@@ -1,4 +1,4 @@
-package org.azukazu.gtm.domain.model.line
+package org.azukazu.gtm.application
 
 /**
  * リプライトークン

--- a/src/main/kotlin/org/azukazu/gtm/domain/model/photozou/PhotozouErrorMessage.kt
+++ b/src/main/kotlin/org/azukazu/gtm/domain/model/photozou/PhotozouErrorMessage.kt
@@ -4,6 +4,7 @@ import org.azukazu.gtm.domain.model.ErrorMessageInterface
 
 /**
  * エラーメッセージ(フォト蔵)
+ * TODO: インフラ層に移動
  */
 enum class PhotozouErrorMessage(val value: String) : ErrorMessageInterface {
 

--- a/src/main/kotlin/org/azukazu/gtm/domain/model/search_word/SearchWord.kt
+++ b/src/main/kotlin/org/azukazu/gtm/domain/model/search_word/SearchWord.kt
@@ -25,6 +25,7 @@ class SearchWord(val value: String) {
                 throw InvalidSearchWordException(GeneralErrorMessage.SEARCH_WORD_IS_BLANK)
             }
 
+            // TODO: バリデーションをインフラ層に移動
             if (Pattern.matches("^[0-9a-zA-Z-~ -/:-@\\[-~]{1,2}$", searchWordValue)) {
                 throw InvalidSearchWordException(PhotozouErrorMessage.SEARCH_WORD_IS_TOO_SHORT)
             }

--- a/src/main/kotlin/org/azukazu/gtm/infrastructure/handler/LineMessageHandler.kt
+++ b/src/main/kotlin/org/azukazu/gtm/infrastructure/handler/LineMessageHandler.kt
@@ -9,7 +9,7 @@ import org.azukazu.gtm.application.JudgeNeedsProcessApplicationService
 import org.azukazu.gtm.application.NotifyLineOfErrorMessageApplicationService
 import org.azukazu.gtm.application.NotifyLineOfImageSearchResultApplicationService
 import org.azukazu.gtm.domain.model.search_word.SearchWord
-import org.azukazu.gtm.domain.model.line.ReplyToken
+import org.azukazu.gtm.application.ReplyToken
 
 @Slf4j
 @LineMessageHandler

--- a/src/main/kotlin/org/azukazu/gtm/infrastructure/transmission/line/messaging_api/LineMessagingApiClient.kt
+++ b/src/main/kotlin/org/azukazu/gtm/infrastructure/transmission/line/messaging_api/LineMessagingApiClient.kt
@@ -1,29 +1,27 @@
-package org.azukazu.gtm.infrastructure.transmission.line
+package org.azukazu.gtm.infrastructure.transmission.line.messaging_api
 
 import com.linecorp.bot.client.LineMessagingClient
 import com.linecorp.bot.model.ReplyMessage
 import com.linecorp.bot.model.message.ImageMessage
 import com.linecorp.bot.model.message.TextMessage
 import com.linecorp.bot.spring.boot.annotation.LineMessageHandler
+import org.azukazu.gtm.application.LineNotificator
 import org.azukazu.gtm.domain.model.ErrorMessageInterface
-import org.azukazu.gtm.domain.model.search_word.SearchWord
-import org.azukazu.gtm.domain.model.line.ReplyToken
 import org.azukazu.gtm.domain.model.image_info.ImageInfo
+import org.azukazu.gtm.application.ReplyToken
+import org.azukazu.gtm.domain.model.search_word.SearchWord
 import org.springframework.stereotype.Component
 
 /**
- * LINEへの通知を行うNotificator
+ * LINE Messaging API を使用するクライアント
  */
 @Component
 @LineMessageHandler
-class LineNotificator(
+class LineMessagingApiClient(
     private val client: LineMessagingClient
-) {
+) : LineNotificator {
 
-    /**
-     * 画像付きメッセージを通知する
-     */
-    fun notifyLineOfImage(
+    override fun notifyOfMessageWithImage(
         replyToken: ReplyToken,
         searchWord: SearchWord,
         imageInfo: ImageInfo) {
@@ -55,10 +53,7 @@ class LineNotificator(
             )
         )
 
-    /**
-     * メッセージを通知する
-     */
-    fun notifyLineOfMessage(
+    override fun notifyOfMessage(
         replyToken: ReplyToken,
         text: String) {
 
@@ -69,14 +64,11 @@ class LineNotificator(
         client.replyMessage(replyMessage).get()
     }
 
-    /**
-     * エラーメッセージを通知する
-     */
-    fun notifyLineOfErrorMessage(
+    override fun notifyErrorMessage(
         replyToken: ReplyToken,
         errorMessage: ErrorMessageInterface) {
 
-        notifyLineOfMessage(replyToken, errorMessage.value())
+        notifyOfMessage(replyToken, errorMessage.value())
     }
 
     /**

--- a/src/main/kotlin/org/azukazu/gtm/infrastructure/transmission/photozou/photozou_api/PhotozouApiClient.kt
+++ b/src/main/kotlin/org/azukazu/gtm/infrastructure/transmission/photozou/photozou_api/PhotozouApiClient.kt
@@ -1,9 +1,10 @@
-package org.azukazu.gtm.infrastructure.transmission.photozou
+package org.azukazu.gtm.infrastructure.transmission.photozou.photozou_api
 
-import org.azukazu.gtm.domain.model.search_word.SearchWord
-import org.azukazu.gtm.domain.model.image_info.Url
+import org.azukazu.gtm.application.PhotozouClient
 import org.azukazu.gtm.domain.model.image_info.ImageInfo
-import org.azukazu.gtm.infrastructure.transmission.photozou.dto.PhotozouApiDto
+import org.azukazu.gtm.domain.model.image_info.Url
+import org.azukazu.gtm.domain.model.search_word.SearchWord
+import org.azukazu.gtm.infrastructure.transmission.photozou.photozou_api.dto.PhotozouApiDto
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
 import java.rmi.UnexpectedException
@@ -12,18 +13,15 @@ import java.rmi.UnexpectedException
  * フォト蔵APIを使用するクライアント
  */
 @Component
-class PhotozouClient(
+class PhotozouApiClient(
     private val restTemplate: RestTemplate
-) {
+) : PhotozouClient {
 
     companion object {
         private const val PHOTOZO_SEARCH_API = "https://api.photozou.jp/rest/search_public.json"
     }
 
-    /**
-     * 画像の検索
-     */
-    fun searchImages(searchWord: SearchWord): List<ImageInfo>? {
+    override fun searchImages(searchWord: SearchWord): List<ImageInfo>? {
 
         val uri = buildString {
             append(PHOTOZO_SEARCH_API)

--- a/src/main/kotlin/org/azukazu/gtm/infrastructure/transmission/photozou/photozou_api/dto/PhotozouApiDto.kt
+++ b/src/main/kotlin/org/azukazu/gtm/infrastructure/transmission/photozou/photozou_api/dto/PhotozouApiDto.kt
@@ -1,4 +1,4 @@
-package org.azukazu.gtm.infrastructure.transmission.photozou.dto
+package org.azukazu.gtm.infrastructure.transmission.photozou.photozou_api.dto
 
 data class PhotozouApiDto(
     val stat: String,


### PR DESCRIPTION
## 目的
- インフラ層の実装を置き換えやすくしたい
  - LINE Messaging API
  - フォト蔵API

## 実装の概要
- インターフェースを仲介させ、依存の方向を下記の通りに変更
  - `アプリケーション層 -> インフラ層` から `インフラ層 -> アプリケーション層` 
- 一部クラスを別パッケージに移動
  - ドメイン層に存在していたが、適切ではなさそう
- 冗長なfunction名を変更