### PR TITLE
Qodo Merge の動作検証

### DIFF
--- a/.github/workflows/qodo-merge.yaml
+++ b/.github/workflows/qodo-merge.yaml
@@ -2,7 +2,7 @@ name: qodo-merge
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
   issue_comment:
 
 permissions:

--- a/.github/workflows/qodo-merge.yaml
+++ b/.github/workflows/qodo-merge.yaml
@@ -1,0 +1,29 @@
+name: qodo-merge
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  qodo_merge:
+    if: ${{ github.event.sender.type != 'Bot' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Codium-ai/pr-agent@main
+        env:
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_DESCRIPTION.CUSTOM_LABELS: "[]"
+          PUBLISH_LABELS: "false"
+          PR_REVIEWER.PERSISTENT_COMMENT: "true"
+          PR_CODE_SUGGESTIONS.PERSISTENT_COMMENT: "true"
+          PR_ADD_DOCS.PERSISTENT_COMMENT: "true"
+          PR_REVIEWER.INLINE_CODE_COMMENTS: "true"
+          PR_DESCRIPTION.EXTRA_INSTRUCTIONS: "日本語で記述してください。"
+          PR_REVIEWER.EXTRA_INSTRUCTIONS: "日本語で記述してください。"
+          PR_CODE_SUGGESTIONS.EXTRA_INSTRUCTIONS: "日本語で回答してください。"

--- a/.github/workflows/qodo-merge.yaml
+++ b/.github/workflows/qodo-merge.yaml
@@ -24,6 +24,6 @@ jobs:
           PR_CODE_SUGGESTIONS.PERSISTENT_COMMENT: "true"
           PR_ADD_DOCS.PERSISTENT_COMMENT: "true"
           PR_REVIEWER.INLINE_CODE_COMMENTS: "true"
-          PR_DESCRIPTION.EXTRA_INSTRUCTIONS: "日本語で記述してください。"
-          PR_REVIEWER.EXTRA_INSTRUCTIONS: "日本語で記述してください。"
-          PR_CODE_SUGGESTIONS.EXTRA_INSTRUCTIONS: "日本語で回答してください。"
+          PR_DESCRIPTION.EXTRA_INSTRUCTIONS: '日本語で記述してください。'
+          PR_REVIEWER.EXTRA_INSTRUCTIONS: '日本語で記述してください。'
+          PR_CODE_SUGGESTIONS.EXTRA_INSTRUCTIONS: '日本語で回答してください。'


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Introduced a new GitHub Actions workflow named `qodo-merge` to automate processes related to pull requests and issue comments.
- Configured the workflow to trigger on specific pull request events (`opened`, `reopened`, `ready_for_review`) and issue comments.
- Set up permissions for writing to issues and pull requests.
- Added a job `qodo_merge` that runs on `ubuntu-latest` and excludes events triggered by bots.
- Integrated the `Codium-ai/pr-agent` action with environment variables tailored for Japanese language support and specific persistent comment settings.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>qodo-merge.yaml</strong><dd><code>Added GitHub Actions workflow for Qodo Merge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/qodo-merge.yaml

<li>Added a new GitHub Actions workflow named <code>qodo-merge</code>.<br> <li> Configured the workflow to trigger on pull request events and issue <br>comments.<br> <li> Set permissions for issues and pull requests to <code>write</code>.<br> <li> Defined a job <code>qodo_merge</code> with conditions to exclude bot-triggered <br>events.<br> <li> Integrated the <code>Codium-ai/pr-agent</code> action with various environment <br>variables for customization, including Japanese language instructions.


</details>


  </td>
  <td><a href="https://github.com/azu-kazu/gazou-tottekuru-man/pull/7/files#diff-ab660a2fada419283ed63bfbf9d63cc2067c8d4ba7f22d03f9835ce17879c7b9">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information