### PR TITLE
Qodo Merge のコードを参考に、モデル名を公式 docs の記法から変更（動作しなかったため）

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,6 +1,6 @@
 [config]
-model="google_ai_studio/gemini-2.0-flash-exp"
-fallback_models=["google_ai_studio/gemini-2.0-flash-exp"]
+model="gemini/gemini-2.0-flash-exp"
+fallback_models=["gemini/gemini-2.0-flash-exp"]
 
 [pr_description] # /describe
 publish_labels = false


### PR DESCRIPTION
## 概要
タイトルの通り

## 参考
- [公式 docs](https://qodo-merge-docs.qodo.ai/usage-guide/changing_a_model/#google-ai-studio) の記載
```
[config] # in configuration.toml
model="google_ai_studio/gemini-1.5-flash"
fallback_models=["google_ai_studio/gemini-1.5-flash"]
```
- [公式リポジトリのコード](https://github.com/qodo-ai/pr-agent/blob/be1dd4bd202135034de738690db2ccfc3b1a3417/pr_agent/algo/__init__.py)
```
    'gemini/gemini-2.0-flash-exp': 1048576,
```